### PR TITLE
Fix session sync time update & add remaning session time to logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #####################################################################
 ## Build project
 ####################################################################
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS base
 WORKDIR /App
 
 # Copy csproj and restore as distinct layers
@@ -21,7 +21,7 @@ RUN dotnet publish -c Release -o out  \
 #####################################################################
 ## Final image
 ####################################################################
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 WORKDIR /App
 COPY --from=base /App/out ./
 

--- a/src/RaceControl/Categories/Formula2.cs
+++ b/src/RaceControl/Categories/Formula2.cs
@@ -135,7 +135,11 @@ public class Formula2(ILogger logger, string url) : ICategory
         var sessionTimeLeft = TimeSpan.ParseExact(sessionTimeData, "c", CultureInfo.InvariantCulture);
         
         // If the session has not jed finalized, stop the execution of the method.
-        if (!_hasStarted || sessionTimeLeft != TimeSpan.Zero) return;
+        if (!_hasStarted || sessionTimeLeft != TimeSpan.Zero)
+        {
+            logger.LogInformation("[Formula 2] Session still active, remaining time left {time}", sessionTimeLeft.ToString("hh:mm:ss"));
+            return;
+        }
         
         logger.LogInformation("[Formula 2] Session finalized, closing API connection");
         _hasStarted = false;

--- a/src/RaceControl/Categories/Formula3.cs
+++ b/src/RaceControl/Categories/Formula3.cs
@@ -138,7 +138,11 @@ public class Formula3(ILogger logger, string url) : ICategory
         var sessionTimeLeft = TimeSpan.ParseExact(sessionTimeData, "c", CultureInfo.InvariantCulture);
         
         // If the session has not jed finalized, stop the execution of the method.
-        if (!_hasStarted || sessionTimeLeft != TimeSpan.Zero) return;
+        if (!_hasStarted || sessionTimeLeft != TimeSpan.Zero)
+        {
+            logger.LogInformation("[Formula 3] Session still active, remaining time left {time}", sessionTimeLeft.ToString("hh:mm:ss"));
+            return;
+        }
         
         logger.LogInformation("[Formula 3] Session finalized, closing API connection");
         _hasStarted = false;

--- a/src/RaceControl/RaceControl.csproj
+++ b/src/RaceControl/RaceControl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -16,14 +16,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+    <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Quartz" Version="3.14.0" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes the issue with the session time update script. Also the remaining time of a session in Formula 2 & 3 is added to the logging. 
Dependencies where also upgraded

Closes #13 & #14