### PR TITLE
fix: canceled event

### DIFF
--- a/src/RaceControl/Jobs/SyncSessionsJob.cs
+++ b/src/RaceControl/Jobs/SyncSessionsJob.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Quartz;
 using RaceControl.Database;
 using RaceControl.Database.Entities;
@@ -17,7 +18,7 @@ public class SyncSessionsJob(RaceControlContext dbContext, ILogger<SyncSessionsJ
     {
         logger.LogInformation("[Session Sync] Synchronizing session data with racing calendars");
         var categories = dbContext.Categories.ToArray();
-        var currentYear = DateTime.UtcNow.Year;
+        var currentYear = context.FireTimeUtc.Year;
 
         foreach (var category in categories)
         {
@@ -30,32 +31,23 @@ public class SyncSessionsJob(RaceControlContext dbContext, ILogger<SyncSessionsJ
                 continue;
             }
 
-            var races = calendar.Races.SelectMany(r => r.Sessions.Select(s => new Session
+            logger.LogInformation("[Session Sync] Check if sessions need to be removed due to cancellations {key}", category.Key);
+            var cancelledRaces = calendar.Races
+                .Where(r => r.Canceled)
+                .ToArray();
+
+            if (cancelledRaces.Length > 0)
             {
-                Id = $"{category.Key}_{currentYear}_{r.Round:00}_{s.Key}",
-                CategoryKey = category.Key,
-                Category = category,
-                Name = r.Name,
-                Key = s.Key,
-                Round = r.Round,
-                Time = s.Value
-            }));
+                logger.LogInformation("[Session Sync] Remove session of cancelled races");
+                await DeleteSessions(category, currentYear, cancelledRaces);
+            }
+            
+            var notCancelledRaces = calendar.Races
+                .Where(r => !r.Canceled)
+                .ToArray();
 
             logger.LogInformation("[Session Sync] Update database sessions for {key}", category.Key);
-            foreach (var race in races)
-            {
-                // Query for a session of the given category, session name, session key and session year
-                var sessionId = $"{category.Key}_{currentYear}_{race.Round:00}_{race.Key}";
-                var existingSession = dbContext.Sessions
-                    .SingleOrDefault(s => s.Id == sessionId);
-
-                // If no session is found in the database, add the new session. Otherwise, the old session
-                // will be updated with the session time.
-                if (null == existingSession)
-                    dbContext.Sessions.Add(race);
-                else
-                    existingSession.Time = race.Time;
-            }
+            UpsertSessions(category, currentYear, notCancelledRaces);
         }
 
         dbContext.ChangeTracker.DetectChanges();
@@ -79,6 +71,63 @@ public class SyncSessionsJob(RaceControlContext dbContext, ILogger<SyncSessionsJ
     }
 
     /// <summary>
+    /// Inserts/update session in the database.
+    /// </summary>
+    /// <param name="category">The related category of the sessions.</param>
+    /// <param name="year">The season year.</param>
+    /// <param name="races">Races where the sessions added/updated.</param>
+    private void UpsertSessions(Category category, int year, CalendarItem[] races)
+    {
+        var sessions = races.SelectMany(r => 
+            r.Sessions.Select(s => new Session 
+                {
+                    Id = $"{category.Key}_{year}_{r.Round:00}_{s.Key}",
+                    CategoryKey = category.Key,
+                    Category = category,
+                    Name = r.Name,
+                    Key = s.Key,
+                    Round = r.Round,
+                    Time = s.Value
+                }
+            ))
+            .ToArray();
+        
+        
+        foreach (var session in sessions)
+        {
+            // Query for a session of the given category, session name, session key and session year
+            var sessionId = $"{category.Key}_{year}_{session.Round:00}_{session.Key}";
+            var existingSession = dbContext.Sessions
+                .SingleOrDefault(s => s.Id == sessionId);
+
+            // If no session is found in the database, add the new session. Otherwise, the old session
+            // will be updated with the session time.
+            if (null == existingSession)
+                dbContext.Sessions.Add(session);
+            else
+                existingSession.Time = session.Time;
+        }
+    }
+
+    /// <summary>
+    /// Removes existing sessions from database.
+    /// </summary>
+    /// <param name="category">The related category of the sessions.</param>
+    /// <param name="year">The season year.</param>
+    /// <param name="races">Races where the sessions will be deleted.</param>
+    private async Task DeleteSessions(Category category, int year, CalendarItem[] races)
+    {
+        var sessionKeys = races.SelectMany(r => 
+                r.Sessions.Select(s => $"{category.Key}_{year}_{r.Round:00}_{s.Key}")
+            )
+            .ToArray();
+
+        await dbContext.Sessions
+            .Where(s => sessionKeys.Contains(s.Id))
+            .ExecuteDeleteAsync();
+    }
+    
+    /// <summary>
     /// The structure of the response from the calendar api.
     /// </summary>
     private record Calendar(
@@ -91,6 +140,7 @@ public class SyncSessionsJob(RaceControlContext dbContext, ILogger<SyncSessionsJ
     private record CalendarItem(
         string Name,
         int Round,
+        bool Canceled,
         Dictionary<string, DateTime> Sessions
     );
 }

--- a/src/RaceControl/Middleware/RobotsTxtMiddleware.cs
+++ b/src/RaceControl/Middleware/RobotsTxtMiddleware.cs
@@ -1,0 +1,31 @@
+namespace RaceControl.Middleware;
+
+public class RobotsTxtMiddleware(RequestDelegate next, IWebHostEnvironment env)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Request.Path.StartsWithSegments("/robots.txt"))
+        {
+           var robotTxtInfo = env.ContentRootFileProvider.GetFileInfo("robots.txt");
+           var output = await File.ReadAllTextAsync(robotTxtInfo.PhysicalPath);
+           
+           context.Response.ContentType = "text/plain";
+           await context.Response.WriteAsync(output);
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}
+
+public static class RobotsTxtMiddlewareExtensions
+{
+    public static IApplicationBuilder UseRobotsTxt(this IApplicationBuilder builder, IWebHostEnvironment env)
+    {
+        return builder.MapWhen(
+            ctx => ctx.Request.Path.StartsWithSegments("/robots.txt"),
+            b => b.UseMiddleware<RobotsTxtMiddleware>(env)
+        );
+    }
+}

--- a/src/RaceControl/Program.cs
+++ b/src/RaceControl/Program.cs
@@ -8,6 +8,7 @@ using Quartz;
 using RaceControl.Database;
 using RaceControl.Hubs;
 using RaceControl.Jobs;
+using RaceControl.Middleware;
 using RaceControl.Services;
 using RaceControl.Track;
 using Serilog;
@@ -88,6 +89,7 @@ builder.Services.AddQuartzHostedService(q => q.WaitForJobsToComplete = true);
 var app = builder.Build();
 app.UseStaticFiles();
 app.UseRouting();
+app.UseRobotsTxt(app.Environment);
 
 // Map controller & related web data
 app.MapControllers();

--- a/src/RaceControl/wwwroot/robot.txt
+++ b/src/RaceControl/wwwroot/robot.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
This PR fixes the issue that canceled events are added to the sessions table in the database. If an event is canceled mid-season, existing session data is removed from the database. Also robot.txt was added

Closes: #29 & #30